### PR TITLE
Enable cross-server teleport via core method

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/commands/migratedb.java
+++ b/src/main/java/com/bekvon/bukkit/residence/commands/migratedb.java
@@ -1,0 +1,39 @@
+package com.bekvon.bukkit.residence.commands;
+
+import com.bekvon.bukkit.residence.Residence;
+import com.bekvon.bukkit.residence.containers.CommandAnnotation;
+import com.bekvon.bukkit.residence.containers.cmd;
+import com.bekvon.bukkit.residence.containers.lm;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Manual migration command to import YAML data into MySQL.
+ */
+public class migratedb implements cmd {
+
+    @Override
+    @CommandAnnotation(simple = false, priority = 5600)
+    public Boolean perform(Residence plugin, CommandSender sender, String[] args, boolean resadmin) {
+        if (!plugin.isUsingMysql()) {
+            plugin.msg(sender, "MySQL\u672a\u542f\u7528");
+            return true;
+        }
+        if (sender instanceof Player && !plugin.getPermissionManager().isResidenceAdmin(sender)) {
+            plugin.msg(sender, lm.General_NoPermission);
+            return true;
+        }
+        try {
+            plugin.migrateToMysql();
+            plugin.msg(sender, "\u6570\u636e\u5df2\u8f6c\u79fb\u5230MySQL");
+        } catch (Exception e) {
+            plugin.msg(sender, "\u8f6c\u79fb\u5931\u8d25: " + e.getMessage());
+        }
+        return true;
+    }
+
+    @Override
+    public void getLocale() {
+        // no locale entries
+    }
+}

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/CrossServerTeleportListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/CrossServerTeleportListener.java
@@ -1,0 +1,36 @@
+package com.bekvon.bukkit.residence.listeners;
+
+import com.bekvon.bukkit.residence.Residence;
+import com.bekvon.bukkit.residence.protection.ClaimedResidence;
+import com.liuchangking.dreamengine.service.RedisManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import redis.clients.jedis.Jedis;
+
+public class CrossServerTeleportListener implements Listener {
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        if (!com.liuchangking.dreamengine.config.Config.redisEnabled) {
+            return;
+        }
+        Player player = event.getPlayer();
+        try (Jedis j = RedisManager.getPool().getResource()) {
+            String key = "res_tp:" + player.getUniqueId();
+            String resName = j.get(key);
+            if (resName != null) {
+                j.del(key);
+                Bukkit.getScheduler().runTaskLater(Residence.getInstance(), () -> {
+                    ClaimedResidence res = Residence.getInstance().getResidenceManager().getByName(resName);
+                    if (res != null) {
+                        res.tpToResidence(player, player, false);
+                    }
+                }, 20L);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/bekvon/bukkit/residence/persistance/MysqlSaveHelper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/persistance/MysqlSaveHelper.java
@@ -1,0 +1,97 @@
+package com.bekvon.bukkit.residence.persistance;
+
+import com.liuchangking.dreamengine.service.MysqlManager;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.DumperOptions.FlowStyle;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class MysqlSaveHelper {
+    private final String serverId;
+    private final Yaml yaml;
+
+    public MysqlSaveHelper(String serverId) {
+        this.serverId = serverId;
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(FlowStyle.BLOCK);
+        options.setIndent(2);
+        options.setAllowUnicode(true);
+        options.setWidth(4096);
+        this.yaml = new Yaml(options);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> loadWorld(String worldName) throws Exception {
+        String sql = "SELECT data, flags, messages FROM residence_worlds WHERE server_id=? AND world_name=?";
+        try (Connection conn = MysqlManager.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, serverId);
+            ps.setString(2, worldName);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Map<String, Object> root = new LinkedHashMap<>();
+                    String data = rs.getString("data");
+                    String flags = rs.getString("flags");
+                    String messages = rs.getString("messages");
+                    if (data != null) {
+                        root.put("Residences", yaml.load(data));
+                    }
+                    if (flags != null) {
+                        root.put("Flags", yaml.load(flags));
+                    }
+                    if (messages != null) {
+                        root.put("Messages", yaml.load(messages));
+                    }
+                    return root;
+                }
+            }
+        }
+        return null;
+    }
+
+    public void saveWorld(String worldName, Map<String, Object> root) throws Exception {
+        String sql = "REPLACE INTO residence_worlds(server_id, world_name, data, flags, messages) VALUES(?,?,?,?,?)";
+        try (Connection conn = MysqlManager.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, serverId);
+            ps.setString(2, worldName);
+            ps.setString(3, root.containsKey("Residences") ? yaml.dump(root.get("Residences")) : null);
+            ps.setString(4, root.containsKey("Flags") ? yaml.dump(root.get("Flags")) : null);
+            ps.setString(5, root.containsKey("Messages") ? yaml.dump(root.get("Messages")) : null);
+            ps.executeUpdate();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> loadPermLists() throws Exception {
+        String sql = "SELECT data FROM residence_permlists WHERE id=1";
+        try (Connection conn = MysqlManager.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            if (rs.next()) {
+                String data = rs.getString(1);
+                if (data != null) {
+                    Map<String, Object> root = new LinkedHashMap<>();
+                    root.put("PermissionLists", yaml.load(data));
+                    return root;
+                }
+            }
+        }
+        return null;
+    }
+
+    public void savePermLists(Map<String, Object> root) throws Exception {
+        String sql = "REPLACE INTO residence_permlists(id, data) VALUES(1, ?)";
+        try (Connection conn = MysqlManager.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, root == null ? null : yaml.dump(root.get("PermissionLists")));
+            ps.executeUpdate();
+        }
+    }
+}

--- a/src/main/java/com/bekvon/bukkit/residence/protection/ClaimedResidence.java
+++ b/src/main/java/com/bekvon/bukkit/residence/protection/ClaimedResidence.java
@@ -13,6 +13,8 @@ import com.bekvon.bukkit.residence.permissions.PermissionManager.ResPerm;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 import com.bekvon.bukkit.residence.signsStuff.Signs;
 import com.bekvon.bukkit.residence.utils.*;
+import com.liuchangking.dreamengine.api.DreamServerAPI;
+import com.liuchangking.dreamengine.service.RedisManager;
 import net.Zrips.CMILib.Container.PageInfo;
 import net.Zrips.CMILib.Locale.LC;
 import net.Zrips.CMILib.RawMessages.RawMessage;
@@ -27,6 +29,7 @@ import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
+import redis.clients.jedis.Jedis;
 
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
@@ -1105,6 +1108,25 @@ public class ClaimedResidence {
                     Residence.getInstance().msg(reqPlayer, lm.Residence_MoveDeny, this.getName());
                     return;
                 }
+            }
+        }
+
+        Residence plugin = Residence.getInstance();
+        if (plugin.isUsingMysql()) {
+            String worldName = this.getPermissions().getWorldName();
+            String targetServerId = plugin.getWorldServerId(worldName);
+            if (!plugin.getServerId().equals(targetServerId)) {
+                if (com.liuchangking.dreamengine.config.Config.redisEnabled) {
+                    try (redis.clients.jedis.Jedis j = com.liuchangking.dreamengine.service.RedisManager.getPool().getResource()) {
+                        j.setex("res_tp:" + targetPlayer.getUniqueId(), 30, this.getName());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+                String targetServer = com.liuchangking.dreamengine.api.DreamServerAPI.getServerName(targetServerId);
+                com.liuchangking.dreamengine.api.DreamServerAPI.sendPlayerToServer(targetPlayer, targetServer);
+                plugin.msg(reqPlayer, "\u6b63\u5728\u524d\u5f80\u5176\u4ed6\u670d\u52a1\u5668\u7684\u9886\u5730...");
+                return;
             }
         }
 

--- a/src/main/java/com/bekvon/bukkit/residence/protection/ResidenceManager.java
+++ b/src/main/java/com/bekvon/bukkit/residence/protection/ResidenceManager.java
@@ -944,15 +944,29 @@ public class ResidenceManager implements ResidenceInterface {
         Set<String> worldnames = new HashSet<String>();
         File saveFolder = new File(plugin.dataFolder, "Save");
         try {
-            File worldFolder = new File(saveFolder, "Worlds");
-            if (plugin.getConfigManager().isLoadEveryWorld() && worldFolder.isDirectory()) {
-                for (File f : worldFolder.listFiles()) {
-                    if (!f.isFile())
-                        continue;
-                    String name = f.getName();
-                    if (!name.startsWith(Residence.saveFilePrefix))
-                        continue;
-                    worldnames.add(name.substring(Residence.saveFilePrefix.length(), name.length() - 4));
+            if (plugin.isUsingMysql()) {
+                try (java.sql.Connection conn = com.liuchangking.dreamengine.service.MysqlManager.getConnection();
+                     java.sql.PreparedStatement ps = conn.prepareStatement("SELECT world_name FROM residence_worlds WHERE server_id=?")) {
+                    ps.setString(1, plugin.getServerId());
+                    try (java.sql.ResultSet rs = ps.executeQuery()) {
+                        while (rs.next()) {
+                            worldnames.add(rs.getString(1));
+                        }
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            } else {
+                File worldFolder = new File(saveFolder, "Worlds");
+                if (plugin.getConfigManager().isLoadEveryWorld() && worldFolder.isDirectory()) {
+                    for (File f : worldFolder.listFiles()) {
+                        if (!f.isFile())
+                            continue;
+                        String name = f.getName();
+                        if (!name.startsWith(Residence.saveFilePrefix))
+                            continue;
+                        worldnames.add(name.substring(Residence.saveFilePrefix.length(), name.length() - 4));
+                    }
                 }
             }
             plugin.getServ().getWorlds().forEach((w) -> {


### PR DESCRIPTION
## Summary
- integrate cross-server redirect logic directly in `tpToResidence`
- revert `/res tp` command to call the core teleport method

## Testing
- `gradle build` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877de5a34788329a57fc9b2132e6a10