### PR TITLE
Introduce mysql.yml with startup checks

### DIFF
--- a/src/main/resources/mysql.yml
+++ b/src/main/resources/mysql.yml
@@ -1,0 +1,1 @@
+enabled: false


### PR DESCRIPTION
## Summary
- add `mysql.yml` config file to enable/disable MySQL support
- load `mysql.yml` in `onEnable` and verify DreamEngine MySQL configuration
- stop the server if MySQL connection fails or DreamEngine's MySQL is disabled

## Testing
- `gradle build` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687816cc227c832990dcba530ffdc9d7