### PR TITLE
Sync residence changes with MySQL

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/Residence.java
+++ b/src/main/java/com/bekvon/bukkit/residence/Residence.java
@@ -583,11 +583,13 @@ public class Residence extends JavaPlugin {
 
 
             int autosaveInt = getConfigManager().getAutoSaveInterval();
-            if (autosaveInt < 1) {
-                autosaveInt = 1;
+            if (!useMysql) {
+                if (autosaveInt < 1) {
+                    autosaveInt = 1;
+                }
+                autosaveInt = autosaveInt * 60 * 20;
+                autosaveBukkitId = CMIScheduler.scheduleSyncRepeatingTask(this, autoSave, autosaveInt, autosaveInt);
             }
-            autosaveInt = autosaveInt * 60 * 20;
-            autosaveBukkitId = CMIScheduler.scheduleSyncRepeatingTask(this, autoSave, autosaveInt, autosaveInt);
 
             if (getConfigManager().getHealInterval() > 0)
                 healBukkitId = CMIScheduler.scheduleSyncRepeatingTask(this, doHeals, 20, getConfigManager().getHealInterval() * 20);
@@ -787,6 +789,52 @@ public class Residence extends JavaPlugin {
 
     public String getServerId() {
         return serverId;
+    }
+
+    /**
+     * Persist a single residence immediately when MySQL mode is enabled.
+     */
+    public void saveResidenceMysql(com.bekvon.bukkit.residence.protection.ClaimedResidence res) {
+        if (!useMysql || res == null)
+            return;
+        com.bekvon.bukkit.residence.persistance.MysqlSaveHelper helper =
+                new com.bekvon.bukkit.residence.persistance.MysqlSaveHelper(serverId);
+        try {
+            helper.saveResidence(res);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Delete a residence record from MySQL immediately.
+     */
+    public void deleteResidenceMysql(String name) {
+        if (!useMysql)
+            return;
+        com.bekvon.bukkit.residence.persistance.MysqlSaveHelper helper =
+                new com.bekvon.bukkit.residence.persistance.MysqlSaveHelper(serverId);
+        try {
+            helper.deleteResidence(name);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Update the name of a residence in MySQL immediately.
+     */
+    public void renameResidenceMysql(String oldName, com.bekvon.bukkit.residence.protection.ClaimedResidence res) {
+        if (!useMysql || res == null)
+            return;
+        com.bekvon.bukkit.residence.persistance.MysqlSaveHelper helper =
+                new com.bekvon.bukkit.residence.persistance.MysqlSaveHelper(serverId);
+        try {
+            helper.renameResidence(oldName, res.getResidenceName());
+            helper.saveResidence(res);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     public PlayerManager getPlayerManager() {

--- a/src/main/java/com/bekvon/bukkit/residence/commands/reset.java
+++ b/src/main/java/com/bekvon/bukkit/residence/commands/reset.java
@@ -44,8 +44,9 @@ public class reset implements cmd {
 	    }
 
 
-	    res.getPermissions().applyDefaultFlags();
-	    plugin.msg(sender, lm.Flag_reset, res.getName());
+            res.getPermissions().applyDefaultFlags();
+            plugin.saveResidenceMysql(res);
+            plugin.msg(sender, lm.Flag_reset, res.getName());
 	    return true;
 	}
 
@@ -57,8 +58,9 @@ public class reset implements cmd {
 	int count = 0;
 	for (World oneW : Bukkit.getWorlds()) {
 	    for (ClaimedResidence one : plugin.getResidenceManager().getFromAllResidences(true, false, oneW)) {
-		one.getPermissions().applyDefaultFlags();
-		count++;
+                one.getPermissions().applyDefaultFlags();
+                plugin.saveResidenceMysql(one);
+                count++;
 	    }
 	}
 	plugin.msg(sender, lm.Flag_resetAll, count);

--- a/src/main/java/com/bekvon/bukkit/residence/itemlist/ResidenceItemList.java
+++ b/src/main/java/com/bekvon/bukkit/residence/itemlist/ResidenceItemList.java
@@ -28,14 +28,16 @@ public class ResidenceItemList extends ItemList {
 
 	ResidencePlayer rPlayer = plugin.getPlayerManager().getResidencePlayer(player);
 	PermissionGroup group = rPlayer.getGroup();
-	if (resadmin || (res.getPermissions().hasResidencePermission(player, true) && group.itemListAccess())) {
-	    if (super.toggle(mat))
-		plugin.msg(player, lm.General_ListMaterialAdd, mat.toString(), type.toString().toLowerCase());
-	    else
-		plugin.msg(player, lm.General_ListMaterialRemove, mat.toString(), type.toString().toLowerCase());
-	} else {
-	    plugin.msg(player, lm.General_NoPermission);
-	}
+        if (resadmin || (res.getPermissions().hasResidencePermission(player, true) && group.itemListAccess())) {
+            boolean added = super.toggle(mat);
+            if (added)
+                plugin.msg(player, lm.General_ListMaterialAdd, mat.toString(), type.toString().toLowerCase());
+            else
+                plugin.msg(player, lm.General_ListMaterialRemove, mat.toString(), type.toString().toLowerCase());
+            plugin.saveResidenceMysql(res);
+        } else {
+            plugin.msg(player, lm.General_NoPermission);
+        }
     }
 
     public static ResidenceItemList load(Residence plugin, ClaimedResidence parent, Map<String, Object> map) {

--- a/src/main/java/com/bekvon/bukkit/residence/protection/ClaimedResidence.java
+++ b/src/main/java/com/bekvon/bukkit/residence/protection/ClaimedResidence.java
@@ -122,6 +122,7 @@ public class ClaimedResidence {
 
     public void setMainResidence(boolean state) {
         mainRes = state;
+        Residence.getInstance().saveResidenceMysql(this);
     }
 
     public boolean isSubzone() {
@@ -412,6 +413,9 @@ public class ClaimedResidence {
         Residence.getInstance().getResidenceManager().removeChunkList(this);
         areas.put(name, area);
         Residence.getInstance().getResidenceManager().calculateChunks(this);
+
+        Residence.getInstance().saveResidenceMysql(this);
+
         return true;
     }
 
@@ -589,6 +593,8 @@ public class ClaimedResidence {
         areas.put(name, newarea);
         Residence.getInstance().getResidenceManager().calculateChunks(this);
 
+        Residence.getInstance().saveResidenceMysql(this);
+
         if (player != null)
             Residence.getInstance().msg(player, lm.Area_Update);
         return true;
@@ -710,6 +716,9 @@ public class ClaimedResidence {
                 return false;
 
             subzones.put(name, newres);
+
+            Residence.getInstance().saveResidenceMysql(newres);
+
             if (player != null) {
                 Residence.getInstance().msg(player, lm.Area_Create, NName);
                 Residence.getInstance().msg(player, lm.Subzone_Create, NName);
@@ -826,6 +835,11 @@ public class ClaimedResidence {
             return false;
         }
         subzones.remove(name);
+
+        if (Residence.getInstance().isUsingMysql()) {
+            Residence.getInstance().deleteResidenceMysql(res.getResidenceName());
+        }
+
         if (player != null) {
             Residence.getInstance().msg(player, lm.Subzone_Remove, name);
         }
@@ -908,6 +922,8 @@ public class ClaimedResidence {
             this.setLeaveMessage(message);
         }
         Residence.getInstance().msg(sender, lm.Residence_MessageChange);
+
+        Residence.getInstance().saveResidenceMysql(this);
     }
 
     public CuboidArea getMainArea() {
@@ -1076,6 +1092,8 @@ public class ClaimedResidence {
         tpLoc = player.getLocation().toVector();
         PitchYaw = new Vector(player.getLocation().getPitch(), player.getLocation().getYaw(), 0);
         Residence.getInstance().msg(player, lm.Residence_SetTeleportLocation);
+
+        Residence.getInstance().saveResidenceMysql(this);
     }
 
     public void tpToResidence(final Player reqPlayer, final Player targetPlayer, final boolean resadmin) {
@@ -1310,6 +1328,8 @@ public class ClaimedResidence {
         Residence.getInstance().getResidenceManager().removeChunkList(this);
         areas.remove(id);
         Residence.getInstance().getResidenceManager().calculateChunks(this);
+
+        Residence.getInstance().saveResidenceMysql(this);
     }
 
     public void removeArea(Player player, String id, boolean resadmin) {
@@ -1332,6 +1352,7 @@ public class ClaimedResidence {
             removeArea(id);
             if (player != null)
                 Residence.getInstance().msg(player, lm.Area_Remove, id);
+            Residence.getInstance().saveResidenceMysql(this);
         } else {
             if (player != null)
                 Residence.getInstance().msg(player, lm.General_NoPermission);
@@ -1691,6 +1712,8 @@ public class ClaimedResidence {
         subzones.put(newName, res);
         subzones.remove(oldName);
 
+        Residence.getInstance().saveResidenceMysql(res);
+
         Residence.getInstance().msg(sender, lm.Subzone_Rename, oldName, newName);
         return true;
     }
@@ -1722,6 +1745,9 @@ public class ClaimedResidence {
             areas.remove(oldName);
             if (player != null)
                 Residence.getInstance().msg(player, lm.Area_Rename, oldName, newName);
+
+            Residence.getInstance().saveResidenceMysql(this);
+
             return true;
         }
         Residence.getInstance().msg(player, lm.General_NoPermission);
@@ -1823,23 +1849,31 @@ public class ClaimedResidence {
     public boolean addCmdBlackList(String cmd) {
         if (cmd.contains("/"))
             cmd = cmd.replace("/", "");
+        boolean added;
         if (!this.cmdBlackList.contains(cmd.toLowerCase())) {
             this.cmdBlackList.add(cmd.toLowerCase());
-            return true;
+            added = true;
+        } else {
+            this.cmdBlackList.remove(cmd.toLowerCase());
+            added = false;
         }
-        this.cmdBlackList.remove(cmd.toLowerCase());
-        return false;
+        Residence.getInstance().saveResidenceMysql(this);
+        return added;
     }
 
     public boolean addCmdWhiteList(String cmd) {
         if (cmd.contains("/"))
             cmd = cmd.replace("/", "");
+        boolean added;
         if (!this.cmdWhiteList.contains(cmd.toLowerCase())) {
             this.cmdWhiteList.add(cmd.toLowerCase());
-            return true;
+            added = true;
+        } else {
+            this.cmdWhiteList.remove(cmd.toLowerCase());
+            added = false;
         }
-        this.cmdWhiteList.remove(cmd.toLowerCase());
-        return false;
+        Residence.getInstance().saveResidenceMysql(this);
+        return added;
     }
 
 

--- a/src/main/java/com/bekvon/bukkit/residence/protection/ResidenceManager.java
+++ b/src/main/java/com/bekvon/bukkit/residence/protection/ResidenceManager.java
@@ -278,6 +278,10 @@ public class ResidenceManager implements ResidenceInterface {
         calculateChunks(newRes);
         plugin.getPlayerManager().addResidence(newRes.getOwner(), newRes);
 
+        if (plugin.isUsingMysql()) {
+            plugin.saveResidenceMysql(newRes);
+        }
+
         if (player != null) {
             Visualizer v = new Visualizer(player);
             v.setAreas(newArea);
@@ -606,6 +610,10 @@ public class ResidenceManager implements ResidenceInterface {
 
         for (ClaimedResidence sub : res.getSubzones()) {
             removeResidence(rPlayer, sub, resadmin, false);
+        }
+
+        if (plugin.isUsingMysql() && parent == null) {
+            plugin.deleteResidenceMysql(res.getResidenceName());
         }
     }
 
@@ -1291,6 +1299,10 @@ public class ResidenceManager implements ResidenceInterface {
 
                 plugin.getSignUtil().updateSignResName(res);
 
+                if (plugin.isUsingMysql()) {
+                    plugin.renameResidenceMysql(oldName, res);
+                }
+
                 plugin.msg(sender, lm.Residence_Rename, oldName, newName);
 
                 return true;
@@ -1393,6 +1405,13 @@ public class ResidenceManager implements ResidenceInterface {
             }
 
             cleanResidenceRecords(next, false);
+
+            if (plugin.isUsingMysql()) {
+                plugin.deleteResidenceMysql(next.getResidenceName());
+                for (ClaimedResidence sub : next.getSubzones()) {
+                    plugin.deleteResidenceMysql(sub.getResidenceName());
+                }
+            }
 
             it.remove();
             count++;

--- a/src/main/java/com/bekvon/bukkit/residence/protection/ResidencePermissions.java
+++ b/src/main/java/com/bekvon/bukkit/residence/protection/ResidencePermissions.java
@@ -407,6 +407,7 @@ public class ResidencePermissions extends FlagPermissions {
                     }
                 }
 
+                Residence.getInstance().saveResidenceMysql(residence);
                 return true;
             }
         }
@@ -451,6 +452,7 @@ public class ResidencePermissions extends FlagPermissions {
                 }
                 if (super.setGroupFlag(group, flag, flagstate)) {
                     Residence.getInstance().msg(player, lm.Flag_Set, flag, residence.getName(), flagstate);
+                    Residence.getInstance().saveResidenceMysql(residence);
                     return true;
                 }
             } else {
@@ -521,6 +523,7 @@ public class ResidencePermissions extends FlagPermissions {
                         break;
                     }
                 }
+                Residence.getInstance().saveResidenceMysql(residence);
                 return true;
             }
         }
@@ -540,6 +543,7 @@ public class ResidencePermissions extends FlagPermissions {
             }
             super.removeAllPlayerFlags(targetPlayer);
             Residence.getInstance().msg(sender, lm.Flag_RemovedAll, targetPlayer, this.residence.getName());
+            Residence.getInstance().saveResidenceMysql(residence);
             return true;
         }
         return false;
@@ -556,6 +560,7 @@ public class ResidencePermissions extends FlagPermissions {
             }
             super.removeAllGroupFlags(group);
             Residence.getInstance().msg(player, lm.Flag_RemovedGroup, group, this.residence.getName());
+            Residence.getInstance().saveResidenceMysql(residence);
             return true;
         }
         return false;
@@ -580,7 +585,11 @@ public class ResidencePermissions extends FlagPermissions {
             if (fc.isCancelled())
                 return false;
         }
-        return super.setGroupFlag(group, flag, state);
+        if (super.setGroupFlag(group, flag, state)) {
+            Residence.getInstance().saveResidenceMysql(residence);
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -591,7 +600,11 @@ public class ResidencePermissions extends FlagPermissions {
             if (fc.isCancelled())
                 return false;
         }
-        return super.setPlayerFlag(player, flag, state);
+        if (super.setPlayerFlag(player, flag, state)) {
+            Residence.getInstance().saveResidenceMysql(residence);
+            return true;
+        }
+        return false;
     }
 
     public void applyDefaultFlags(Player player, boolean resadmin) {
@@ -631,6 +644,8 @@ public class ResidencePermissions extends FlagPermissions {
                 this.setGroupFlag(entry.getKey(), flag.getKey(), flag.getValue() ? FlagState.TRUE : FlagState.FALSE);
             }
         }
+
+        Residence.getInstance().saveResidenceMysql(residence);
     }
 
 
@@ -651,6 +666,8 @@ public class ResidencePermissions extends FlagPermissions {
 
         if (resetFlags)
             this.applyDefaultFlags();
+
+        Residence.getInstance().saveResidenceMysql(residence);
 
         return true;
     }
@@ -686,6 +703,8 @@ public class ResidencePermissions extends FlagPermissions {
         Residence.getInstance().getPlayerManager().addResidence(ownerLastKnownName, residence);
         if (resetFlags)
             this.applyDefaultFlags();
+
+        Residence.getInstance().saveResidenceMysql(residence);
     }
 
     public String getOwner() {


### PR DESCRIPTION
## Summary
- add helper methods in `Residence` to save, delete and rename residences in MySQL
- write item list and permission edits directly to the database
- load player residence lists from MySQL if enabled
- persist various residence modifications immediately
- update `/res reset` so default flag resets are saved to MySQL

## Testing
- `gradle --no-daemon build` *(fails to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878eec871bc83299896b7b605cf5685