### PR TITLE
Improve cross-server teleport

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/commands/list.java
+++ b/src/main/java/com/bekvon/bukkit/residence/commands/list.java
@@ -95,14 +95,22 @@ public class list implements cmd {
         CrossPlatformMenu<String> menu = CrossUI.stringMenu(player);
         menu.title("领地列表");
         for (ClaimedResidence res : owned.values()) {
-            String worldName = res.getWorldName();
-            String serverId = plugin.getWorldServerId(worldName);
+            String resName = res.getName();
+            String serverId = plugin.getResidenceServerId(resName);
             String serverName = DreamServerAPI.getServerName(serverId);
             String label = res.getName() + " - " + serverName;
             menu.button(label, res.getName());
         }
         menu.onClick(ev -> {
-            ClaimedResidence res = plugin.getResidenceManager().getByName(ev.getPayload());
+            String resName = ev.getPayload();
+            String serverId = plugin.getResidenceServerId(resName);
+            if (!plugin.getServerId().equals(serverId)) {
+                player.closeInventory();
+                plugin.sendPlayerToResidenceServer(player, resName, serverId);
+                return;
+            }
+
+            ClaimedResidence res = plugin.getResidenceManager().getByName(resName);
             if (res != null) {
                 player.closeInventory();
                 res.tpToResidence(player, player, resadmin);

--- a/src/main/java/com/bekvon/bukkit/residence/protection/ClaimedResidence.java
+++ b/src/main/java/com/bekvon/bukkit/residence/protection/ClaimedResidence.java
@@ -13,8 +13,6 @@ import com.bekvon.bukkit.residence.permissions.PermissionManager.ResPerm;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 import com.bekvon.bukkit.residence.signsStuff.Signs;
 import com.bekvon.bukkit.residence.utils.*;
-import com.liuchangking.dreamengine.api.DreamServerAPI;
-import com.liuchangking.dreamengine.service.RedisManager;
 import net.Zrips.CMILib.Container.PageInfo;
 import net.Zrips.CMILib.Locale.LC;
 import net.Zrips.CMILib.RawMessages.RawMessage;
@@ -29,7 +27,6 @@ import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
-import redis.clients.jedis.Jedis;
 
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
@@ -1131,19 +1128,10 @@ public class ClaimedResidence {
 
         Residence plugin = Residence.getInstance();
         if (plugin.isUsingMysql()) {
-            String worldName = this.getPermissions().getWorldName();
-            String targetServerId = plugin.getWorldServerId(worldName);
+            String resName = this.getName();
+            String targetServerId = plugin.getResidenceServerId(resName);
             if (!plugin.getServerId().equals(targetServerId)) {
-                if (com.liuchangking.dreamengine.config.Config.redisEnabled) {
-                    try (redis.clients.jedis.Jedis j = com.liuchangking.dreamengine.service.RedisManager.getPool().getResource()) {
-                        j.setex("res_tp:" + targetPlayer.getUniqueId(), 30, this.getName());
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-                String targetServer = com.liuchangking.dreamengine.api.DreamServerAPI.getServerName(targetServerId);
-                com.liuchangking.dreamengine.api.DreamServerAPI.sendPlayerToServer(targetPlayer, targetServer);
-                plugin.msg(reqPlayer, "\u6b63\u5728\u524d\u5f80\u5176\u4ed6\u670d\u52a1\u5668\u7684\u9886\u5730...");
+                plugin.sendPlayerToResidenceServer(targetPlayer, resName, targetServerId);
                 return;
             }
         }


### PR DESCRIPTION
## Summary
- add `sendPlayerToResidenceServer` helper in `Residence`
- use the new helper from list command and teleport logic
- remove redundant imports and use Chinese text directly

## Testing
- `gradle build` *(fails to resolve dependencies due to 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_687b8ac131748329934120e7017ce288