### PR TITLE
Handle special lore items in upgrades

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/Residence.java
+++ b/src/main/java/com/bekvon/bukkit/residence/Residence.java
@@ -28,6 +28,8 @@ import com.liuchangking.dreamengine.api.DreamServerAPI;
 import com.liuchangking.dreamengine.utils.MessageUtil;
 import com.residence.mcstats.Metrics;
 import com.residence.zip.ZipLibrary;
+import com.bekvon.bukkit.residence.landcore.LandCoreManager;
+import com.bekvon.bukkit.residence.landcore.LandCoreListener;
 import net.Zrips.CMILib.Colors.CMIChatColor;
 import net.Zrips.CMILib.Items.CMIMaterial;
 import net.Zrips.CMILib.Version.Schedulers.CMIScheduler;
@@ -98,6 +100,9 @@ public class Residence extends JavaPlugin {
     protected Sorting SortingManager;
     protected AutoSelection AutoSelectionManager;
     private InformationPager InformationPagerManager;
+
+    // Land core module
+    protected LandCoreManager landCoreManager;
 
     protected CommandFiller cmdFiller;
 
@@ -263,6 +268,10 @@ public class Residence extends JavaPlugin {
             effectRemoveBukkitId.cancel();
         if (despawnMobsBukkitId != null)
             despawnMobsBukkitId.cancel();
+
+        if (landCoreManager != null) {
+            landCoreManager.save();
+        }
 
         this.getPermissionManager().stopCacheClearScheduler();
 
@@ -574,6 +583,10 @@ public class Residence extends JavaPlugin {
 
             AutoSelectionManager = new AutoSelection(this);
 
+            landCoreManager = new LandCoreManager(this);
+            landCoreManager.load();
+            getServer().getPluginManager().registerEvents(new LandCoreListener(this, landCoreManager), this);
+
             try {
                 Class.forName("org.bukkit.event.player.PlayerItemDamageEvent");
                 getServer().getPluginManager().registerEvents(new SpigotListener(), this);
@@ -793,6 +806,10 @@ public class Residence extends JavaPlugin {
 
     public RandomTp getRandomTpManager() {
         return RandomTpManager;
+    }
+
+    public LandCoreManager getLandCoreManager() {
+        return landCoreManager;
     }
 
     public EconomyInterface getEconomyManager() {

--- a/src/main/java/com/bekvon/bukkit/residence/commands/landcore.java
+++ b/src/main/java/com/bekvon/bukkit/residence/commands/landcore.java
@@ -1,0 +1,57 @@
+package com.bekvon.bukkit.residence.commands;
+
+import com.bekvon.bukkit.residence.LocaleManager;
+import com.bekvon.bukkit.residence.Residence;
+import com.bekvon.bukkit.residence.containers.CommandAnnotation;
+import com.bekvon.bukkit.residence.containers.cmd;
+import com.bekvon.bukkit.residence.containers.lm;
+import com.bekvon.bukkit.residence.landcore.LandCoreManager;
+import net.Zrips.CMILib.FileHandler.ConfigReader;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Arrays;
+
+public class landcore implements cmd {
+
+    @Override
+    @CommandAnnotation(simple = true, priority = 5700)
+    public Boolean perform(Residence plugin, CommandSender sender, String[] args, boolean resadmin) {
+        if (!(sender instanceof Player))
+            return false;
+        if (!plugin.getPermissionManager().isResidenceAdmin(sender)) {
+            plugin.msg(sender, lm.General_NoPermission);
+            return true;
+        }
+        if (args.length < 1 || args.length > 2)
+            return false;
+        int level;
+        try {
+            level = Integer.parseInt(args[0]);
+        } catch (Exception e) {
+            return false;
+        }
+        Player target = (args.length == 2) ? Bukkit.getPlayer(args[1]) : (Player) sender;
+        if (target == null) {
+            plugin.msg(sender, lm.Invalid_Player, args[1]);
+            return true;
+        }
+        LandCoreManager manager = plugin.getLandCoreManager();
+        ItemStack core = manager.createCoreItem(level);
+        target.getInventory().addItem(core);
+        plugin.msg(sender, "\u5df2\u83b7\u5f97\u7b49\u7ea7" + level + "\u7684\u9886\u5730\u6838\u5fc3");
+        if (target != sender)
+            plugin.msg(target, "\u5df2\u83b7\u5f97\u7b49\u7ea7" + level + "\u7684\u9886\u5730\u6838\u5fc3");
+        return true;
+    }
+
+    @Override
+    public void getLocale() {
+        ConfigReader c = Residence.getInstance().getLocaleManager().getLocaleConfig();
+        c.get("Description", "\u7ed9\u4e88\u9886\u5730\u6838\u5fc3");
+        c.get("Info", Arrays.asList("&eUsage: &6/res landcore <level> [player]"));
+        LocaleManager.addTabCompleteMain(this, "<level>", "[playername]");
+    }
+}

--- a/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreConfig.java
+++ b/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreConfig.java
@@ -1,0 +1,157 @@
+package com.bekvon.bukkit.residence.landcore;
+
+import net.Zrips.CMILib.Locale.YmlMaker;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Configuration for LandCore module. */
+public class LandCoreConfig {
+    private final JavaPlugin plugin;
+    private final File file;
+    private FileConfiguration cfg;
+    public static class UpgradeItem {
+        private final int amount;
+        private final String lore;
+
+        public UpgradeItem(int amount, String lore) {
+            this.amount = amount;
+            this.lore = lore;
+        }
+
+        public int getAmount() {
+            return amount;
+        }
+
+        public String getLore() {
+            return lore;
+        }
+    }
+
+    public static class UpgradeCost {
+        private final int money;
+        private final java.util.List<UpgradeItem> items;
+
+        public UpgradeCost(int money, java.util.List<UpgradeItem> items) {
+            this.money = money;
+            this.items = items;
+        }
+
+        public int getMoney() {
+            return money;
+        }
+
+        public java.util.List<UpgradeItem> getItems() {
+            return items;
+        }
+    }
+
+    private final Map<Integer, UpgradeCost> upgradeCosts = new HashMap<>();
+    public static class CoreItem {
+        private final String name;
+        private final List<String> lore;
+
+        public CoreItem(String name, List<String> lore) {
+            this.name = name;
+            this.lore = lore;
+        }
+
+        public String getName() { return name; }
+        public List<String> getLore() { return lore; }
+    }
+
+    private String defaultItemName;
+    private List<String> defaultItemLore = new ArrayList<>();
+    private final Map<Integer, CoreItem> itemMap = new HashMap<>();
+
+    public LandCoreConfig(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "landcore.yml");
+    }
+
+    public void load() {
+        if (!file.exists()) {
+            try {
+                file.getParentFile().mkdirs();
+                YmlMaker yml = new YmlMaker(plugin, "landcore.yml");
+                yml.saveDefaultConfig();
+                yml.ConfigFile.renameTo(file);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        cfg = YamlConfiguration.loadConfiguration(file);
+        upgradeCosts.clear();
+        if (cfg.isConfigurationSection("upgrade-costs")) {
+            for (String k : cfg.getConfigurationSection("upgrade-costs").getKeys(false)) {
+                int level = Integer.parseInt(k);
+                int money = 0;
+                List<UpgradeItem> items = new ArrayList<>();
+                if (cfg.isConfigurationSection("upgrade-costs." + k)) {
+                    var sec = cfg.getConfigurationSection("upgrade-costs." + k);
+                    money = sec.getInt("money", 0);
+                    if (sec.isList("items")) {
+                        for (Object obj : sec.getList("items")) {
+                            if (!(obj instanceof Map<?,?> map)) continue;
+                            Object amtObj = map.get("amount");
+                            Object loreObj = map.get("lore");
+                            int amt = amtObj instanceof Number ? ((Number) amtObj).intValue() : 1;
+                            String lore = loreObj == null ? null : String.valueOf(loreObj);
+                            items.add(new UpgradeItem(amt, lore));
+                        }
+                    }
+                } else {
+                    money = cfg.getInt("upgrade-costs." + k, 0);
+                }
+                upgradeCosts.put(level, new UpgradeCost(money, items));
+            }
+        }
+        defaultItemName = cfg.getString("item.default.name", "§a%level_cn%领地核心");
+        defaultItemLore = cfg.getStringList("item.default.lore");
+        itemMap.clear();
+        if (cfg.isConfigurationSection("item")) {
+            var sec = cfg.getConfigurationSection("item");
+            for (String k : sec.getKeys(false)) {
+                if ("default".equalsIgnoreCase(k)) continue;
+                int lvl;
+                try { lvl = Integer.parseInt(k); } catch (NumberFormatException e) { continue; }
+                String name = sec.getString(k+".name", defaultItemName);
+                List<String> lore = sec.getStringList(k+".lore");
+                if (lore.isEmpty()) lore = new ArrayList<>(defaultItemLore);
+                itemMap.put(lvl, new CoreItem(name, lore));
+            }
+        }
+    }
+
+    public UpgradeCost getUpgradeCost(int level) {
+        return upgradeCosts.getOrDefault(level, new UpgradeCost(0, new ArrayList<>()));
+    }
+
+    public FileConfiguration getConfig() {
+        return cfg;
+    }
+
+    public CoreItem getItem(int level) {
+        CoreItem it = itemMap.get(level);
+        if (it != null) return it;
+        return new CoreItem(defaultItemName,
+                new ArrayList<>(defaultItemLore));
+    }
+
+    public void setItem(int level, String name, List<String> lore) {
+        CoreItem ci = new CoreItem(name, lore);
+        itemMap.put(level, ci);
+        cfg.set("item."+level+".name", name);
+        cfg.set("item."+level+".lore", lore);
+    }
+
+    public void save() {
+        try { cfg.save(file); } catch (Exception ignored) {}
+    }
+}

--- a/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreData.java
+++ b/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreData.java
@@ -1,0 +1,28 @@
+package com.bekvon.bukkit.residence.landcore;
+
+/** Data for a placed land core. */
+public class LandCoreData {
+    private int level;
+    private String residenceName;
+
+    public LandCoreData(int level, String residenceName) {
+        this.level = level;
+        this.residenceName = residenceName;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    public String getResidenceName() {
+        return residenceName;
+    }
+
+    public void setResidenceName(String residenceName) {
+        this.residenceName = residenceName;
+    }
+}

--- a/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreListener.java
@@ -1,0 +1,82 @@
+package com.bekvon.bukkit.residence.landcore;
+
+import com.bekvon.bukkit.residence.Residence;
+import com.liuchangking.dreamengine.api.CrossPlatformMenu;
+import com.liuchangking.dreamengine.api.CrossUI;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.GameMode;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+public class LandCoreListener implements Listener {
+    private final Residence plugin;
+    private final LandCoreManager manager;
+    private final NamespacedKey key;
+
+    public LandCoreListener(Residence plugin, LandCoreManager manager) {
+        this.plugin = plugin;
+        this.manager = manager;
+        this.key = new NamespacedKey(plugin, "landcore");
+    }
+
+    private boolean isCoreItem(ItemStack item) {
+        if (item == null || item.getType() != Material.PLAYER_HEAD) return false;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return false;
+        PersistentDataContainer pdc = meta.getPersistentDataContainer();
+        return pdc.has(key, PersistentDataType.INTEGER);
+    }
+
+    private int parseLevel(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            PersistentDataContainer pdc = meta.getPersistentDataContainer();
+            Integer lvl = pdc.get(key, PersistentDataType.INTEGER);
+            if (lvl != null) return lvl;
+        }
+        return 1;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onPlace(BlockPlaceEvent event) {
+        ItemStack item = event.getItemInHand();
+        if (!isCoreItem(item)) return;
+        event.setCancelled(true);
+        int lvl = parseLevel(item);
+        manager.placeCore(event.getPlayer(), event.getBlockPlaced().getLocation(), item, lvl);
+        if (event.getPlayer().getGameMode() != GameMode.CREATIVE) {
+            item.setAmount(item.getAmount()-1);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onInteract(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        Block block = event.getClickedBlock();
+        if (block == null || block.getType() != Material.PLAYER_HEAD) return;
+        if (!manager.isCore(block)) return;
+        event.setCancelled(true);
+        CrossPlatformMenu<String> menu = CrossUI.stringMenu(event.getPlayer());
+        menu.title("领地核心");
+        menu.button("领地升级", "upgrade");
+        menu.button("领地设置", "set");
+        menu.onClick(ev -> {
+            if ("upgrade".equals(ev.getPayload())) {
+                manager.upgrade(ev.getPlayer(), block);
+            } else if ("set".equals(ev.getPayload())) {
+                ev.getPlayer().performCommand("res set " + manager.get(block).getResidenceName());
+            }
+        });
+        menu.open(event.getPlayer());
+    }
+}

--- a/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreManager.java
+++ b/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreManager.java
@@ -1,0 +1,219 @@
+package com.bekvon.bukkit.residence.landcore;
+
+import com.bekvon.bukkit.residence.Residence;
+import com.bekvon.bukkit.residence.protection.ClaimedResidence;
+import com.liuchangking.dreamengine.shop.hook.VaultHook;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.Skull;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.persistence.PersistentDataType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+
+/** Manager for land cores. */
+public class LandCoreManager {
+    private final Residence plugin;
+    private final LandCoreConfig config;
+    private final Map<String, LandCoreData> cores = new HashMap<>();
+    private final NamespacedKey coreKey;
+
+    public LandCoreManager(Residence plugin) {
+        this.plugin = plugin;
+        this.config = new LandCoreConfig(plugin);
+        this.coreKey = new NamespacedKey(plugin, "landcore");
+    }
+
+    public void load() {
+        config.load();
+        if (config.getConfig().isConfigurationSection("cores")) {
+            for (String key : config.getConfig().getConfigurationSection("cores").getKeys(false)) {
+                int lvl = config.getConfig().getInt("cores."+key+".level",1);
+                String res = config.getConfig().getString("cores."+key+".res");
+                cores.put(key, new LandCoreData(lvl, res));
+            }
+        }
+    }
+
+    public void save() {
+        for (Map.Entry<String, LandCoreData> e : cores.entrySet()) {
+            config.getConfig().set("cores."+e.getKey()+".level", e.getValue().getLevel());
+            config.getConfig().set("cores."+e.getKey()+".res", e.getValue().getResidenceName());
+        }
+        config.save();
+    }
+
+    private String key(Location loc) {
+        return loc.getWorld().getName()+","+loc.getBlockX()+","+loc.getBlockY()+","+loc.getBlockZ();
+    }
+
+    public boolean isCore(Block block) {
+        return cores.containsKey(key(block.getLocation()));
+    }
+
+    public LandCoreData get(Block block) {
+        return cores.get(key(block.getLocation()));
+    }
+
+    /**
+     * Create a land core item with the specified level.
+     */
+    public ItemStack createCoreItem(int level) {
+        ItemStack item = new ItemStack(Material.PLAYER_HEAD);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            LandCoreConfig.CoreItem def = config.getItem(level);
+            String name = def.getName();
+            name = name.replace("%level%", String.valueOf(level));
+            name = name.replace("%level_cn%", chineseNumber(level));
+            meta.setDisplayName(name);
+            meta.getPersistentDataContainer().set(coreKey, PersistentDataType.INTEGER, level);
+            List<String> lore = def.getLore();
+            if (lore != null && !lore.isEmpty()) {
+                meta.setLore(lore.stream()
+                        .map(l -> l.replace("%level%", String.valueOf(level))
+                                .replace("%level_cn%", chineseNumber(level)))
+                        .toList());
+            }
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private String chineseNumber(int level) {
+        String[] arr = {"零","一","二","三","四","五","六","七","八","九","十"};
+        if (level >= 0 && level < arr.length) {
+            return arr[level];
+        }
+        return String.valueOf(level);
+    }
+
+    public void placeCore(Player player, Location loc, ItemStack item, int level) {
+        World world = loc.getWorld();
+        int chunkX = loc.getChunk().getX();
+        int chunkZ = loc.getChunk().getZ();
+        int radius = level - 1;
+        int minX = (chunkX - radius) * 16;
+        int maxX = (chunkX + radius) * 16 + 15;
+        int minZ = (chunkZ - radius) * 16;
+        int maxZ = (chunkZ + radius) * 16 + 15;
+        int minY = world.getMinHeight();
+        int maxY = world.getMaxHeight() - 1;
+        Location loc1 = new Location(world, minX, minY, minZ);
+        Location loc2 = new Location(world, maxX, maxY, maxZ);
+        String resName = "core_"+loc.getBlockX()+"_"+loc.getBlockZ()+"_"+player.getName();
+        if (!plugin.getResidenceManager().addResidence(player, resName, loc1, loc2, false)) {
+            return; // creation failed
+        }
+        // floor and border
+        int floorY = loc.getBlockY() - 1;
+        for (int x=minX; x<=maxX; x++) {
+            for (int z=minZ; z<=maxZ; z++) {
+                world.getBlockAt(x,floorY,z).setType(Material.OAK_PLANKS);
+                if (x==minX || x==maxX || z==minZ || z==maxZ) {
+                    world.getBlockAt(x, loc.getBlockY(), z).setType(Material.STONE_SLAB);
+                }
+            }
+        }
+        Block core = loc.getBlock();
+        core.setType(Material.PLAYER_HEAD);
+        if (core.getState() instanceof Skull skull && item.getItemMeta() instanceof SkullMeta sm) {
+            skull.setPlayerProfile(sm.getPlayerProfile());
+            skull.getPersistentDataContainer().set(coreKey, PersistentDataType.INTEGER, level);
+            skull.update(true);
+        }
+        LandCoreData data = new LandCoreData(level,resName);
+        cores.put(key(loc), data);
+        save();
+    }
+
+    private int countMatchingItems(Player player, LandCoreConfig.UpgradeItem req) {
+        int count = 0;
+        for (ItemStack is : player.getInventory().getContents()) {
+            if (is == null) continue;
+            ItemMeta meta = is.getItemMeta();
+            if (meta == null || !meta.hasLore()) continue;
+            boolean match = false;
+            if (req.getLore() == null) {
+                match = true;
+            } else {
+                for (String l : meta.getLore()) {
+                    if (l != null && l.contains(req.getLore())) {
+                        match = true;
+                        break;
+                    }
+                }
+            }
+            if (match) count += is.getAmount();
+        }
+        return count;
+    }
+
+    private void removeMatchingItems(Player player, LandCoreConfig.UpgradeItem req, int amount) {
+        ItemStack[] contents = player.getInventory().getContents();
+        for (int i = 0; i < contents.length && amount > 0; i++) {
+            ItemStack is = contents[i];
+            if (is == null) continue;
+            ItemMeta meta = is.getItemMeta();
+            if (meta == null || !meta.hasLore()) continue;
+            boolean match = false;
+            if (req.getLore() == null) {
+                match = true;
+            } else {
+                for (String l : meta.getLore()) {
+                    if (l != null && l.contains(req.getLore())) {
+                        match = true;
+                        break;
+                    }
+                }
+            }
+            if (!match) continue;
+            int take = Math.min(is.getAmount(), amount);
+            is.setAmount(is.getAmount() - take);
+            if (is.getAmount() == 0) contents[i] = null;
+            amount -= take;
+        }
+        player.getInventory().setContents(contents);
+    }
+
+    public void upgrade(Player player, Block block) {
+        LandCoreData data = get(block);
+        if (data == null) return;
+        int level = data.getLevel();
+        if (level >= 5) {
+            player.sendMessage("已经到达最大等级");
+            return;
+        }
+        LandCoreConfig.UpgradeCost cost = config.getUpgradeCost(level + 1);
+        int money = cost.getMoney();
+        // check item availability first
+        for (LandCoreConfig.UpgradeItem it : cost.getItems()) {
+            if (countMatchingItems(player, it) < it.getAmount()) {
+                String name = it.getLore() == null ? "物品" : it.getLore();
+                player.sendMessage("缺少物品: " + name + " x" + it.getAmount());
+                return;
+            }
+        }
+        if (money > 0 && !VaultHook.takeMoney(player, money)) {
+            player.sendMessage("金币不足," + money);
+            return;
+        }
+        for (LandCoreConfig.UpgradeItem it : cost.getItems()) {
+            removeMatchingItems(player, it, it.getAmount());
+        }
+        // remove old residence
+        ClaimedResidence res = plugin.getResidenceManager().getByName(data.getResidenceName());
+        if (res != null) {
+            plugin.getResidenceManager().removeResidence(res);
+        }
+        data.setLevel(level+1);
+        placeCore(player, block.getLocation(), createCoreItem(data.getLevel()), data.getLevel());
+    }
+}

--- a/src/main/resources/landcore.yml
+++ b/src/main/resources/landcore.yml
@@ -1,0 +1,22 @@
+upgrade-costs:
+  2:
+    money: 1000
+    # items:
+    #   - lore: "升级核心"
+    #     amount: 1
+  3:
+    money: 3000
+  4:
+    money: 6000
+  5:
+    money: 10000
+item:
+  default:
+    name: "§a%level_cn%领地核心"
+    lore:
+      - "放置后创建领地"
+      - "等级: %level_cn%"
+  #1:
+  #  name: "§a一级领地核心"
+  #  lore:
+  #    - "自定义 lore"


### PR DESCRIPTION
## Summary
- treat upgrade items solely by lore instead of material
- add Chinese level names via `%level_cn%` placeholder
- tweak land core item name defaults
- allow configuring each level's core item separately
- simplify item config path

## Testing
- `gradle test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687e71c51b80832989a72b2afe7c9f4f