### PR TITLE
Remove LandCore login update check

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreListener.java
@@ -90,10 +90,6 @@ public class LandCoreListener implements Listener {
         menu.open(event.getPlayer());
     }
 
-    @EventHandler
-    public void onJoin(PlayerJoinEvent event) {
-        manager.updatePlayerInventory(event.getPlayer());
-    }
 
     @EventHandler(ignoreCancelled = true)
     public void onBreak(BlockBreakEvent event) {


### PR DESCRIPTION
## Summary
- remove PlayerJoinEvent handler that updated land core items

## Testing
- `gradle build` *(fails: 403 Forbidden when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687fe515fc2c83298cd3937382495919