### PR TITLE
Add withdraw option for land core

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreListener.java
@@ -84,6 +84,9 @@ public class LandCoreListener implements Listener {
         menu.title("领地核心");
         menu.buttonAt(0, Material.NETHER_STAR, "领地升级", "领地升级", lore, "upgrade");
         menu.buttonAt(1, Material.BOOK, "领地设置", "领地设置", "set");
+        menu.buttonAt(7, Material.BARRIER, "收回领地", "收回领地",
+                java.util.Collections.singletonList("§7这会删除并清空你的领地"),
+                "withdraw");
         final Block coreBlock = block;
         final java.util.List<String> upgradeLore = lore;
         menu.onClick(ev -> {
@@ -108,6 +111,18 @@ public class LandCoreListener implements Listener {
             } else if ("set".equals(ev.getPayload())) {
                 ev.getPlayer().closeInventory();
                 ev.getPlayer().performCommand("res set " + manager.get(coreBlock).getResidenceName());
+            } else if ("withdraw".equals(ev.getPayload())) {
+                CrossUI.menu(ev.getPlayer(), String.class)
+                        .title("确认收回领地?")
+                        .buttonAt(3, Material.LIME_WOOL, "确定", "yes")
+                        .buttonAt(5, Material.RED_WOOL, "取消", "no")
+                        .onClick(resp -> {
+                            resp.getPlayer().closeInventory();
+                            if ("yes".equals(resp.getPayload())) {
+                                manager.withdraw(resp.getPlayer(), coreBlock);
+                            }
+                        })
+                        .open(ev.getPlayer());
             }
         });
         menu.open(player);

--- a/src/main/java/com/bekvon/bukkit/residence/landcore/restore/AsyncChunkScanner.java
+++ b/src/main/java/com/bekvon/bukkit/residence/landcore/restore/AsyncChunkScanner.java
@@ -1,0 +1,59 @@
+package com.bekvon.bukkit.residence.landcore.restore;
+
+import org.bukkit.Chunk;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.Location;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Scan a chunk asynchronously and schedule clearing of ores and containers.
+ */
+public class AsyncChunkScanner extends BukkitRunnable {
+    private final JavaPlugin plugin;
+    private final Chunk chunk;
+    private final Player player;
+
+    public AsyncChunkScanner(JavaPlugin plugin, Chunk chunk, Player player) {
+        this.plugin = plugin;
+        this.chunk = chunk;
+        this.player = player;
+    }
+
+    @Override
+    public void run() {
+        World world = chunk.getWorld();
+        int minY = world.getMinHeight();
+        int maxY = world.getMaxHeight();
+
+        List<Location> toClear = new ArrayList<>();
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                for (int y = minY; y < maxY; y++) {
+                    Block b = chunk.getBlock(x, y, z);
+                    Material m = b.getType();
+                    if (isOre(m) || m == Material.CHEST || m == Material.TRAPPED_CHEST || m == Material.SPAWNER) {
+                        toClear.add(b.getLocation());
+                    }
+                }
+            }
+        }
+
+        new ChunkClearTask(toClear, player).runTaskTimer(plugin, 0L, 1L);
+    }
+
+    private boolean isOre(Material m) {
+        return switch (m) {
+            case COAL_ORE, IRON_ORE, GOLD_ORE, REDSTONE_ORE,
+                 DIAMOND_ORE, EMERALD_ORE, COPPER_ORE, LAPIS_ORE,
+                 NETHER_QUARTZ_ORE, NETHER_GOLD_ORE -> true;
+            default -> false;
+        };
+    }
+}

--- a/src/main/java/com/bekvon/bukkit/residence/landcore/restore/ChunkClearTask.java
+++ b/src/main/java/com/bekvon/bukkit/residence/landcore/restore/ChunkClearTask.java
@@ -1,0 +1,36 @@
+package com.bekvon.bukkit.residence.landcore.restore;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.List;
+
+/**
+ * Remove blocks from the provided locations in small batches on the main thread.
+ */
+public class ChunkClearTask extends BukkitRunnable {
+    private final List<Location> toClear;
+    private final Player player;
+    private int index = 0;
+    private static final int BATCH_SIZE = 512;
+
+    public ChunkClearTask(List<Location> toClear, Player player) {
+        this.toClear = toClear;
+        this.player = player;
+    }
+
+    @Override
+    public void run() {
+        int processed = 0;
+        while (processed < BATCH_SIZE && index < toClear.size()) {
+            Location loc = toClear.get(index++);
+            loc.getBlock().setType(Material.AIR, false);
+            processed++;
+        }
+        if (index >= toClear.size()) {
+            cancel();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add async chunk clear util classes
- support removing hologram for a single land core
- implement `withdraw` method on LandCoreManager
- add "收回领地" GUI button with confirmation
- check for chests before withdrawing and add warning lore
- notify player when chest check begins

## Testing
- `gradle build -x test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68813a14557c8329ac16124512e85605