### PR TITLE
Ensure land core exists on teleport

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/landcore/LandCoreListener.java
@@ -77,6 +77,11 @@ public class LandCoreListener implements Listener {
         Block block = event.getClickedBlock();
         if (block == null || block.getType() != Material.PLAYER_HEAD) return;
         if (!manager.isCore(block)) return;
+        if (manager.isWithdrawing(block)) {
+            event.setCancelled(true);
+            MessageUtil.notifyError(event.getPlayer(), "正在收回", "领地正在回收中");
+            return;
+        }
         event.setCancelled(true);
         Player player = event.getPlayer();
         int level = manager.get(block).getLevel();

--- a/src/main/java/com/bekvon/bukkit/residence/protection/ClaimedResidence.java
+++ b/src/main/java/com/bekvon/bukkit/residence/protection/ClaimedResidence.java
@@ -1136,6 +1136,9 @@ public class ClaimedResidence {
             }
         }
 
+        // Ensure land core exists before teleporting (async check)
+        plugin.getLandCoreManager().ensureCoreExistsAsync(this);
+
         SafeLocationCache old = Residence.getInstance().getTeleportMap().get(targetPlayer.getUniqueId());
 
         if (Bukkit.getWorld(this.getPermissions().getWorldName()) == null)


### PR DESCRIPTION
## Summary
- add helper methods to `LandCoreManager` to look up and recreate land cores
- check and regenerate the core asynchronously when teleporting to a residence
- prevent opening the land core menu during withdrawal
- add `/res landcore remove` subcommand to remove the residence created by the core

## Testing
- `gradle test` *(fails: Could not resolve dependencies due to 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68836ef8756c8329becf493c0571be48